### PR TITLE
more Fluency configurables

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Place the `.jar` in your classpath or using maven:
   <version>1.2.0</version>
 </dependency>
 ```
- 
+
 ## Usage
 
 ```xml
@@ -36,6 +36,18 @@ Place the `.jar` in your classpath or using maven:
             <!-- you can add as may as you like (or none at all) -->
             <StaticField name="application">yourApplication</StaticField>
             <StaticField name="someOtherField">some value</StaticField>
+            <Server host="primary-node" port="24224"/>
+            <Server host="secondary-node" port="24224"/>
+            <FluencyConfig
+              ackResponseMode="true"
+              fileBackupDir="/tmp/fluency"
+              bufferChunkInitialSize="4194304"
+              bufferChunkRetentionSize="16777216"
+              maxBufferSize="268435456"
+              waitUntilBufferFlushed="30"
+              waitUntilFlusherTerminated="40"
+              flushIntervalMillis="200"
+              senderMaxRetryCount="12" />
         </Fluency>
     </Appenders>
     <Loggers>
@@ -59,7 +71,7 @@ Place the `.jar` in your classpath or using maven:
 The appender gets initialized by log4j and creates a new `Fluency.defaultFluency();`.
 
 All log messages get aggregated with some additional fields and handed over to fluency.
- 
+
 fluency will forward the messages to a fluentd running on localhost.
 
 ## License

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.komamitsu</groupId>
             <artifactId>fluency</artifactId>
-            <version>1.0.0</version>
+            <version>1.1.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>

--- a/src/com/wywy/log4j/appender/FluencyConfig.java
+++ b/src/com/wywy/log4j/appender/FluencyConfig.java
@@ -1,0 +1,79 @@
+package com.wywy.log4j.appender;
+
+import org.apache.logging.log4j.core.config.Node;
+import org.apache.logging.log4j.core.config.plugins.Plugin;
+import org.apache.logging.log4j.core.config.plugins.PluginAttribute;
+import org.apache.logging.log4j.core.config.plugins.PluginFactory;
+import org.komamitsu.fluency.Fluency;
+
+/**
+ * Represents Fluency params in the configuration.
+ */
+@Plugin(name = "FluencyConfig", category = Node.CATEGORY, printObject = true)
+public class FluencyConfig {
+
+    private boolean ackResponseMode;
+    private String fileBackupDir;
+    private int bufferChunkInitialSize;
+    private int bufferChunkRetentionSize;
+    private Long maxBufferSize;
+    private int waitUntilBufferFlushed;
+    private int waitUntilFlusherTerminated;
+    private int flushIntervalMillis;
+    private int senderMaxRetryCount;
+
+    private FluencyConfig() {
+    }
+
+    public Fluency.Config configure() {
+        Fluency.Config config = new Fluency.Config().setAckResponseMode(ackResponseMode);
+        if (fileBackupDir != null) config.setFileBackupDir(fileBackupDir);
+        if (bufferChunkInitialSize > 0) config.setBufferChunkInitialSize(bufferChunkInitialSize);
+        if (bufferChunkRetentionSize > 0) config.setBufferChunkRetentionSize(bufferChunkRetentionSize);
+        if (maxBufferSize > 0) config.setMaxBufferSize(maxBufferSize);
+        if (waitUntilBufferFlushed > 0) config.setWaitUntilBufferFlushed(waitUntilBufferFlushed);
+        if (waitUntilFlusherTerminated > 0) config.setWaitUntilFlusherTerminated(waitUntilFlusherTerminated);
+        if (flushIntervalMillis > 0) config.setFlushIntervalMillis(flushIntervalMillis);
+        if (senderMaxRetryCount > 0) config.setSenderMaxRetryCount(senderMaxRetryCount);
+        return config;
+    }
+
+    @PluginFactory
+    public static FluencyConfig createFluencyConfig(
+            @PluginAttribute("ackResponseMode") final boolean ackResponseMode,
+            @PluginAttribute("fileBackupDir") final String fileBackupDir,
+            @PluginAttribute("bufferChunkInitialSize") final int bufferChunkInitialSize,
+            @PluginAttribute("bufferChunkRetentionSize") final int bufferChunkRetentionSize,
+            @PluginAttribute("maxBufferSize") final Long maxBufferSize,
+            @PluginAttribute("waitUntilBufferFlushed") final int waitUntilBufferFlushed,
+            @PluginAttribute("waitUntilFlusherTerminated") final int waitUntilFlusherTerminated,
+            @PluginAttribute("flushIntervalMillis") final int flushIntervalMillis,
+            @PluginAttribute("senderMaxRetryCount") final int senderMaxRetryCount) {
+        FluencyConfig config = new FluencyConfig();
+        config.ackResponseMode = ackResponseMode;
+        config.fileBackupDir = fileBackupDir;
+        config.bufferChunkInitialSize = bufferChunkInitialSize;
+        config.bufferChunkRetentionSize = bufferChunkRetentionSize;
+        config.maxBufferSize = maxBufferSize;
+        config.waitUntilBufferFlushed = waitUntilBufferFlushed;
+        config.waitUntilFlusherTerminated = waitUntilFlusherTerminated;
+        config.flushIntervalMillis = flushIntervalMillis;
+        config.senderMaxRetryCount = senderMaxRetryCount;
+        return config;
+    }
+
+    @Override
+    public String toString() {
+        return "FluencyConfig{" +
+                "ackResponseMode=" + ackResponseMode +
+                ", fileBackupDir='" + fileBackupDir + '\'' +
+                ", bufferChunkInitialSize=" + bufferChunkInitialSize +
+                ", bufferChunkRetentionSize=" + bufferChunkRetentionSize +
+                ", maxBufferSize=" + maxBufferSize +
+                ", waitUntilBufferFlushed=" + waitUntilBufferFlushed +
+                ", waitUntilFlusherTerminated=" + waitUntilFlusherTerminated +
+                ", flushIntervalMillis=" + flushIntervalMillis +
+                ", senderMaxRetryCount=" + senderMaxRetryCount +
+                '}';
+    }
+}

--- a/src/com/wywy/log4j/appender/Server.java
+++ b/src/com/wywy/log4j/appender/Server.java
@@ -1,0 +1,51 @@
+package com.wywy.log4j.appender;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.config.Node;
+import org.apache.logging.log4j.core.config.plugins.Plugin;
+import org.apache.logging.log4j.core.config.plugins.PluginAttribute;
+import org.apache.logging.log4j.core.config.plugins.PluginFactory;
+import org.apache.logging.log4j.status.StatusLogger;
+
+import java.net.InetSocketAddress;
+
+/**
+ * Represents a host/port pair in the configuration.
+ */
+@Plugin(name = "Server", category = Node.CATEGORY, printObject = true)
+public class Server {
+
+    private static final Logger LOGGER = StatusLogger.getLogger();
+
+    private final String host;
+    private final int port;
+
+    private Server(final String host, final int port) {
+        this.host = host;
+        this.port = port;
+    }
+
+    public InetSocketAddress configure() {
+        return new InetSocketAddress(host, port);
+    }
+
+    @PluginFactory
+    public static Server createServer(@PluginAttribute("host") final String host,
+            @PluginAttribute("port") final int port) {
+        if (host == null) {
+            LOGGER.error("Property host cannot be null");
+        }
+        if (port <= 0) {
+            LOGGER.error("Property port must be > 0");
+        }
+        return new Server(host, port);
+    }
+
+    @Override
+    public String toString() {
+        return "Server{" +
+                "host='" + host + '\'' +
+                ", port=" + port +
+                '}';
+    }
+}


### PR DESCRIPTION
This p-r adds new options named *Server* and *FluencyConfig*, to set Fluentd nodes and parameters for Fluency in the log4j configuration (also upgraded Fluency version to 1.1.0).

I made this patch bacause I'd like to use this plugin on production environment.

it would be nice if you could check this.

Thanks.