### PR TITLE
Upgrade log4j to version 2.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,12 +57,12 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.1</version><!-- same version as storm -->
+            <version>2.7</version><!-- same version as storm -->
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.1</version>
+            <version>2.7</version>
         </dependency>
     </dependencies>
 

--- a/src/com/wywy/log4j/appender/FluencyAppender.java
+++ b/src/com/wywy/log4j/appender/FluencyAppender.java
@@ -132,8 +132,11 @@ public final class FluencyAppender extends AbstractAppender {
     public void append(LogEvent logEvent) {
         String level = logEvent.getLevel().name();
         String loggerName = logEvent.getLoggerName();
+        StringBuilder loggerNameAbbr = new StringBuilder();
         String message = new String(this.getLayout().toByteArray(logEvent));
         Date eventTime = new Date(logEvent.getTimeMillis());
+
+        abbr.abbreviate(loggerName, loggerNameAbbr);
 
         Map<String, Object> m = new HashMap<>();
         m.put("level", level);
@@ -164,7 +167,7 @@ public final class FluencyAppender extends AbstractAppender {
             m.put("sourceLine", logEvent.getSource().getLineNumber());
         }
 
-        m.put("logger", abbr.abbreviate(loggerName));
+        m.put("logger", loggerNameAbbr.toString());
         m.put("loggerFull", loggerName);
         m.put("message", message);
         m.put("thread", logEvent.getThreadName());


### PR DESCRIPTION
There is a slight change in the log4j api in 2.7. The abbreviate function now requires a StringBuilder in stead of returning a String.

I'm trying to use log4j-plugin-fluency with ElasticSearch 5.3.1, which in turn ships by default with log4j 2.7. There was a change in the 2.7 api with respect to the abbreviate function which makes that the fluency plugin won't come up properly.

This is a quick fix, which made log4j-plugin-fluency work with ElasticSearch 5. It might not be the most clean way to solve the API change, so let me know if some improvement is needed for a merge.